### PR TITLE
bugfix nil error

### DIFF
--- a/kong/plugins/prometheus/exporter.lua
+++ b/kong/plugins/prometheus/exporter.lua
@@ -52,8 +52,8 @@ local function log(message)
     return
   end
 
-  local service_name = message.service and message.service.name or
-                       message.service.host
+  local service_name = message.service and (message.service.name or
+                       message.service.host)
   service_name = service_name or ""
 
   metrics.status:inc(1, { message.response.status, service_name })


### PR DESCRIPTION
```shell 
2018/09/06 19:17:52 [error] 29168#0: *1842620 lua entry thread aborted: runtime error: ...local/share/lua/5.1/kong/plugins/prometheus/exporter.lua:66: attempt to index field 'service' (a nil value)
stack traceback:
coroutine 0:
	...local/share/lua/5.1/kong/plugins/prometheus/exporter.lua: in function 'log'
	.../local/share/lua/5.1/kong/plugins/prometheus/handler.lua:16: in function <.../local/share/lua/5.1/kong/plugins/prometheus/handler.lua:11>, context: ngx.timer, client: 100.116.243.152, server: 0.0.0.0:80
2018/09/06 19:22:14 [warn] 29168#0: *1851893 an upstream response is buffered to a temporary file /usr/local/kong/proxy_temp/1/13/0000000131 while reading upstream, client: 100.116.243.183, server: kong, request: "POST /graphql HTTP/1.1", upstream: "http://10.10.1.153:27653/graphql", host: "xxxxxxx"
2018/09/06 19:22:28 [error] 29167#0: *1852495 lua entry thread aborted: runtime error: ...local/share/lua/5.1/kong/plugins/prometheus/exporter.lua:66: attempt to index field 'service' (a nil value)
```